### PR TITLE
fix: remove default margin of body tag

### DIFF
--- a/lib/src/web_svg_view.dart
+++ b/lib/src/web_svg_view.dart
@@ -4,7 +4,7 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 // ignore: must_be_immutable
 class SvgImage extends StatefulWidget {
-  SvgImage({super.key, required this.svgString,required this.onElementClick});
+  SvgImage({super.key, required this.svgString, required this.onElementClick});
   String svgString;
   Function(String) onElementClick;
 
@@ -50,6 +50,9 @@ class _SvgImageState extends State<SvgImage> {
 <head>
     <title>Interactive SVG</title>
     <style>
+        body {
+            margin: 0;
+        }
         svg {
             width: 100%;
             height: auto;


### PR DESCRIPTION
It seems that using the SvgImage widget causes unwanted margins around the image. This appears to be due to the default margin set on the <body> tag within the WebView. This pull request removes that default margin.

## Before
<img src="https://github.com/user-attachments/assets/75d19fad-5fbc-482a-abe9-935ca40e4c73" width="300" />

## After
<img src="https://github.com/user-attachments/assets/b269edd7-074e-4191-bcd1-5e19b219ff25" width="300" />
